### PR TITLE
fix: use linear attenuation in SpatialEmitter by default

### DIFF
--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -66,7 +66,7 @@ pub struct SpatialEmitter {
 impl Default for SpatialEmitter {
     fn default() -> Self {
         Self {
-            attenuation: None,
+            attenuation: Some(Easing::Linear),
             enable_spatialization: true,
             distances: EmitterDistances::default(),
         }

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -66,7 +66,7 @@ pub struct SpatialEmitter {
 impl Default for SpatialEmitter {
     fn default() -> Self {
         Self {
-            attenuation: Some(Easing::Linear),
+            attenuation: Some(Easing::OutPowi(2)),
             enable_spatialization: true,
             distances: EmitterDistances::default(),
         }


### PR DESCRIPTION
## Description

- I noticed the spatial example didn't change volume as you moved the camera away from the sphere
- This is because the `default` for `SpatialEmitter` didn't set an attenuation
- With this change, the defaults are what users expect (as I expected), and also match [Kira's default]
- See [Discord messages] for the original report

[Kira's default]: https://github.com/tesselode/kira/blob/975df00e3aa4c75db7596a568a4e513223000d05/crates/kira/src/spatial/emitter/settings.rs#L28
[Discord messages]: https://discord.com/channels/691052431525675048/749430447326625812/1236596362255138816

## Testing

- Ran the spatial example and observed the sound diminish as I moved the camera away from the sphere, and observed the sound come back in as I moved the camera back towards the sphere