### PR TITLE
Remove `Result<(), E>` from the API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,12 +271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
-name = "atomic-arena"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5450eca8ce5abcfd5520727e975ebab30ccca96030550406b0ca718b224ead10"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,7 +303,9 @@ name = "bevy-kira-components"
 version = "0.1.1"
 dependencies = [
  "bevy",
+ "bevy_math",
  "kira",
+ "mint",
  "serde",
  "thiserror",
 ]
@@ -720,11 +716,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f312b1b8aa6d3965b65040b08e33efac030db3071f20b44f9da9c4c3dfcaf76"
+checksum = "f06daa26ffb82d90ba772256c0ba286f6c305c392f6976c9822717974805837c"
 dependencies = [
- "glam",
+ "glam 0.25.0",
  "serde",
 ]
 
@@ -734,7 +730,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3075c01f2b1799945892d5310fc1836e47c045dfe6af5878a304a475931a0c5f"
 dependencies = [
- "glam",
+ "glam 0.25.0",
 ]
 
 [[package]]
@@ -780,7 +776,7 @@ dependencies = [
  "bevy_utils",
  "downcast-rs",
  "erased-serde",
- "glam",
+ "glam 0.25.0",
  "serde",
  "smol_str",
  "thiserror",
@@ -1598,7 +1594,7 @@ checksum = "95ed933078d2e659745df651f4c180511cd582e5b9414ff896e7d50d207e3103"
 dependencies = [
  "const_panic",
  "encase_derive",
- "glam",
+ "glam 0.25.0",
  "thiserror",
 ]
 
@@ -1892,7 +1888,7 @@ dependencies = [
  "vec_map",
  "wasm-bindgen",
  "web-sys",
- "windows 0.48.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -1915,6 +1911,15 @@ dependencies = [
  "bytemuck",
  "mint",
  "serde",
+]
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+dependencies = [
+ "mint",
 ]
 
 [[package]]
@@ -2092,7 +2097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f33ddb7f7143d9e703c072e88b98cd8b9719f174137a671429351bd2ee43c02a"
 dependencies = [
  "constgebra",
- "glam",
+ "glam 0.25.0",
 ]
 
 [[package]]
@@ -2265,18 +2270,18 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kira"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8968f1eda49cdf4f6406fd5ffe590c3ca2778a1b0e50b5684974b138a99dfb2f"
+version = "0.8.6"
+source = "git+https://github.com/tesselode/kira.git?branch=main#3ec7efe5408b6658645b1777ff7be37af5f32eb6"
 dependencies = [
- "atomic-arena",
  "cpal",
- "glam",
+ "glam 0.27.0",
  "mint",
+ "paste",
  "ringbuf",
  "send_wrapper",
  "serde",
  "symphonia",
+ "triple_buffer",
 ]
 
 [[package]]
@@ -3637,6 +3642,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "triple_buffer"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316e1ab00252ce5980b8a70eb50f9818f47a20d341394c56ffab88e764b3caed"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,6 @@ dependencies = [
  "bevy_math",
  "cpal",
  "kira",
- "mint",
  "serde",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ version = "0.1.1"
 dependencies = [
  "bevy",
  "bevy_math",
+ "cpal",
  "kira",
  "mint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 
 [dependencies]
 bevy_math = { version = "0.13.2", features = ["mint"] }
+cpal = "0.15.3"
 kira = { version = "0.8.6", git = "https://github.com/tesselode/kira.git", branch = "main", features = ["serde"] }
 mint = "0.5.9"
 thiserror = "1.0.57"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kira = { version = "0.8.7", features = ["serde"] }
+bevy_math = { version = "0.13.2", features = ["mint"] }
+kira = { version = "0.8.6", git = "https://github.com/tesselode/kira.git", branch = "main", features = ["serde"] }
+mint = "0.5.9"
 thiserror = "1.0.57"
 serde = { version = "1.0.197", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ edition = "2021"
 bevy_math = { version = "0.13.2", features = ["mint"] }
 cpal = "0.15.3"
 kira = { version = "0.8.6", git = "https://github.com/tesselode/kira.git", branch = "main", features = ["serde"] }
-mint = "0.5.9"
 thiserror = "1.0.57"
 serde = { version = "1.0.197", features = ["derive"] }
 

--- a/examples/audio_control.rs
+++ b/examples/audio_control.rs
@@ -2,7 +2,7 @@
 //! For loading additional audio formats, you can enable the corresponding feature for that audio format.
 
 use bevy::prelude::*;
-use bevy::utils::error;
+
 use bevy_kira_components::kira::sound::{PlaybackRate, PlaybackState};
 use bevy_kira_components::kira::tween::Tween;
 use bevy_kira_components::prelude::*;
@@ -35,7 +35,7 @@ fn update_speed(
 ) {
     if let Ok(mut control) = music_controller.get_single_mut() {
         let factor = ((time.elapsed_seconds() / 5.0).sin() + 1.0).max(0.1);
-        error(control.set_playback_rate(PlaybackRate::Factor(factor as f64), Tween::default()));
+        control.set_playback_rate(PlaybackRate::Factor(factor as f64), Tween::default());
     }
 }
 
@@ -47,10 +47,10 @@ fn pause(
         if let Ok(mut control) = music_controller.get_single_mut() {
             match control.playback_state() {
                 PlaybackState::Playing => {
-                    error(control.pause(Tween::default()));
+                    control.pause(Tween::default());
                 }
                 PlaybackState::Pausing | PlaybackState::Paused => {
-                    error(control.resume(Tween::default()));
+                    control.resume(Tween::default());
                 }
                 PlaybackState::Stopping | PlaybackState::Stopped => {}
             }
@@ -66,10 +66,10 @@ fn volume(
     if let Ok(mut control) = music_controller.get_single_mut() {
         if keyboard_input.just_pressed(KeyCode::Equal) {
             *target_volume += 0.1;
-            error(control.set_volume(*target_volume + 1.0, Tween::default()));
+            control.set_volume(*target_volume + 1.0, Tween::default());
         } else if keyboard_input.just_pressed(KeyCode::Minus) {
             *target_volume -= 0.1;
-            error(control.set_volume(*target_volume + 1.0, Tween::default()));
+            control.set_volume(*target_volume + 1.0, Tween::default());
         }
     }
 }

--- a/examples/custom_sound/src/sine_wave.rs
+++ b/examples/custom_sound/src/sine_wave.rs
@@ -17,7 +17,7 @@ use ringbuf::{HeapConsumer, HeapProducer, HeapRb};
 pub struct SineWavePlugin;
 
 impl Plugin for SineWavePlugin {
-    fn build(&self, app: &mut bevy::prelude::App) {
+    fn build(&self, app: &mut App) {
         app.add_plugins(AudioSourcePlugin::<SineWave>::default());
     }
 }
@@ -39,14 +39,14 @@ enum SineWaveCommand {
     SetFrequency(Value<f32>, Tween),
 }
 
-/// Implementation of [`kira::sound::Sound`] that generates a sine wave at the given frequency.
+/// Implementation of [`Sound`] that generates a sine wave at the given frequency.
 struct SineWaveSound {
     /// Output destination. This tells kira where to route the audio data that the output of our
     /// `Sound` implementation
     output: kira::OutputDestination,
     /// Commands receiver (aka. a consumer) of commands sent from other threads
     commands: HeapConsumer<SineWaveCommand>,
-    /// Sine wave frequency (in Hz). Reuses `kira`'s [`kira::tween::Parameter`] struct to provide
+    /// Sine wave frequency (in Hz). Reuses `kira`'s [`Parameter`] struct to provide
     /// click-free changes and ability to provide modulations.
     frequency: Parameter<f32>,
     /// Internal phase of the sine wave. We keep track of the phase instead of the time, as this
@@ -55,16 +55,16 @@ struct SineWaveSound {
 }
 
 impl Sound for SineWaveSound {
-    fn output_destination(&mut self) -> bevy_kira_components::kira::OutputDestination {
+    fn output_destination(&mut self) -> kira::OutputDestination {
         self.output
     }
 
     fn process(
         &mut self,
         dt: f64,
-        clock_info_provider: &bevy_kira_components::kira::clock::clock_info::ClockInfoProvider,
-        modulator_value_provider: &bevy_kira_components::kira::modulator::value_provider::ModulatorValueProvider,
-    ) -> bevy_kira_components::kira::dsp::Frame {
+        clock_info_provider: &kira::clock::clock_info::ClockInfoProvider,
+        modulator_value_provider: &kira::modulator::value_provider::ModulatorValueProvider,
+    ) -> kira::Frame {
         // Receive and perform commands
         while let Some(command) = self.commands.pop() {
             match command {
@@ -84,7 +84,7 @@ impl Sound for SineWaveSound {
         let sample = 0.125 * f32::sin(TAU * self.phase);
 
         // Return the new stereo sample
-        kira::dsp::Frame {
+        kira::Frame {
             left: sample,
             right: sample,
         }

--- a/examples/interactive/src/main.rs
+++ b/examples/interactive/src/main.rs
@@ -1,5 +1,4 @@
 use bevy::prelude::*;
-use bevy::utils::error;
 
 use bevy_kira_components::kira::sound::Region;
 use bevy_kira_components::kira::tween::Tween;

--- a/examples/interactive/src/main.rs
+++ b/examples/interactive/src/main.rs
@@ -68,12 +68,12 @@ fn handle_interactive_sound(
     }
     if keyboard.just_pressed(KeyCode::Space) {
         for (mut handle, mut sprite) in &mut q {
-            error(handle.resume(Tween::default()));
+            handle.resume(Tween::default());
             sprite.color = Color::GREEN;
         }
     } else if keyboard.just_released(KeyCode::Space) {
         for (mut handle, mut sprite) in &mut q {
-            error(handle.pause(Tween::default()));
+            handle.pause(Tween::default());
             sprite.color = Color::GRAY;
         }
     }

--- a/examples/spatial/src/main.rs
+++ b/examples/spatial/src/main.rs
@@ -1,6 +1,5 @@
 use bevy::math::vec3;
 use bevy::prelude::*;
-use bevy::utils::error;
 
 use bevy_kira_components::kira::sound::{PlaybackRate, Region};
 use bevy_kira_components::kira::tween::Tween;

--- a/examples/spatial/src/main.rs
+++ b/examples/spatial/src/main.rs
@@ -153,6 +153,6 @@ fn fake_doppler_effect(
         let local_dir = Vec3::normalize(cam_transform.translation - transform.translation());
         doppler.0 = (SPEED_OF_SOUND - cam_motion.motion().dot(local_dir))
             / (SPEED_OF_SOUND - motion.motion().dot(local_dir));
-        error(handle.set_playback_rate(PlaybackRate::Factor(doppler.0 as _), Tween::default()));
+        handle.set_playback_rate(PlaybackRate::Factor(doppler.0 as _), Tween::default());
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,111 @@
+{
+  "nodes": {
+    "cargo-smart-release-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1704385492,
+        "narHash": "sha256-x+m7F7gGlRF0Nr2220MajNXxjZNmXf6S64B9VMMSMFk=",
+        "owner": "Byron",
+        "repo": "cargo-smart-release",
+        "rev": "7892013f41557d8df5390a6f2855bb5e79632fe6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Byron",
+        "ref": "v0.21.3",
+        "repo": "cargo-smart-release",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1713520724,
+        "narHash": "sha256-CO8MmVDmqZX2FovL75pu5BvwhW+Vugc7Q6ze7Hj8heI=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "c5037590290c6c7dae2e42e7da1e247e54ed2d49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1714782413,
+        "narHash": "sha256-tbg0MEuKaPcUrnmGCu4xiY5F+7LW2+ECPKVAJd2HLwM=",
+        "path": "/nix/store/05jf7swanajlk1fz7fxc00fx1qwga6zk-source",
+        "rev": "651b4702e27a388f0f18e1b970534162dec09aff",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1715037484,
+        "narHash": "sha256-OUt8xQFmBU96Hmm4T9tOWTu4oCswCzoVl+pxSq/kiFc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ad7efee13e0d216bf29992311536fce1d3eefbef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "cargo-smart-release-src": "cargo-smart-release-src",
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    naersk.url = "github:nix-community/naersk";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    cargo-smart-release-src = {
+      url = "github:Byron/cargo-smart-release/v0.21.3";
+      flake = false;
+    };
+  };
+
+  outputs = { self, flake-utils, naersk, nixpkgs, cargo-smart-release-src }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = (import nixpkgs) {
+          inherit system;
+        };
+        inherit (pkgs) lib;
+
+        naersk' = pkgs.callPackage naersk {};
+
+        nativeBuildInputs = with pkgs; [ cmake ninja pkg-config ];
+        buildInputs = with pkgs; [
+          udev alsa-lib vulkan-loader
+          xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXrandr # To use the x11 feature
+          libxkbcommon wayland # To use the wayland feature
+        ];
+
+        cargo-smart-release = naersk'.buildPackage {
+          inherit nativeBuildInputs;
+          buildInputs = with pkgs; [openssl];
+          src = cargo-smart-release-src;
+          singleStep = true;
+        };
+
+        bevy-kira-components = naersk'.buildPackage {
+          inherit nativeBuildInputs;
+          buildInputs = with pkgs; [pkg-config alsa-lib];
+          src = ./.;
+        };
+      in {
+
+        packages = {
+          inherit cargo-smart-release bevy-kira-components;
+          default = bevy-kira-components;
+        };
+
+        # For `nix develop`:
+        devShell = pkgs.mkShell {
+          nativeBuildInputs = nativeBuildInputs ++ buildInputs ++ [cargo-smart-release];
+          LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+        };
+      }
+    );
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,13 +1,14 @@
 use std::fmt;
 use std::fmt::Formatter;
 
-pub use ::cpal::*;
 use bevy::prelude::*;
 use cpal::traits::DeviceTrait;
 use kira::manager::backend::cpal::{CpalBackend, CpalBackendSettings};
 use kira::manager::backend::mock::{MockBackend, MockBackendSettings};
 use kira::manager::backend::{Backend, Renderer};
 use thiserror::Error;
+
+pub use cpal::*;
 
 /// Allows the user to select an audio backend.
 ///
@@ -17,7 +18,7 @@ use thiserror::Error;
 pub enum AudioBackendSelector {
     /// Physical audio backend. Sets up the output stream to use actual audio outputs.
     Physical {
-        /// Select a audio device to use to output the audio. `None` lets the system decide which
+        /// Select an audio device to use to output the audio. `None` lets the system decide which
         /// audio device to use.
         device: Option<cpal::Device>,
         /// Set a specific buffer size for the audio callback coming from the audio device.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -45,7 +45,7 @@ impl Backend for AudioBackend {
     fn setup(settings: Self::Settings) -> Result<(Self, u32), Self::Error> {
         match settings {
             AudioBackendSelector::Physical => {
-                let (backend, sample_rate) = CpalBackend::setup(())?;
+                let (backend, sample_rate) = CpalBackend::setup(default())?;
                 Ok((Self::Physical(backend), sample_rate))
             }
             AudioBackendSelector::Mock { sample_rate } => {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -4,9 +4,9 @@ use std::fmt::Formatter;
 pub use ::cpal::*;
 use bevy::prelude::*;
 use cpal::traits::DeviceTrait;
-use kira::manager::backend::{Backend, Renderer};
 use kira::manager::backend::cpal::{CpalBackend, CpalBackendSettings};
 use kira::manager::backend::mock::{MockBackend, MockBackendSettings};
+use kira::manager::backend::{Backend, Renderer};
 use thiserror::Error;
 
 /// Allows the user to select an audio backend.
@@ -21,8 +21,8 @@ pub enum AudioBackendSelector {
         /// audio device to use.
         device: Option<cpal::Device>,
         /// Set a specific buffer size for the audio callback coming from the audio device.
-        /// 
-        /// Audio devices do not process audio data sample by sample; they instead process audio 
+        ///
+        /// Audio devices do not process audio data sample by sample; they instead process audio
         /// data in chunks. This field controls whether you request a specific size for that chunk.
         /// The audio device is not required to honor that request.
         buffer_size: cpal::BufferSize,

--- a/src/sources/audio_file/mod.rs
+++ b/src/sources/audio_file/mod.rs
@@ -133,17 +133,14 @@ impl Default for AudioFileSettings {
 
 fn play_sound_error_transmute<Out>(err: PlaySoundError<()>) -> PlaySoundError<Out> {
     match err {
-        PlaySoundError::CommandError(cmd) => PlaySoundError::CommandError(cmd),
         PlaySoundError::SoundLimitReached => PlaySoundError::SoundLimitReached,
-        _ => unreachable!(),
+        _ => unreachable!("Cannot magically go from () to {}", std::any::type_name::<Out>()),
     }
 }
 
 fn play_sound_error_cast<In, Out: From<In>>(err: PlaySoundError<In>) -> PlaySoundError<Out> {
     match err {
-        PlaySoundError::CommandError(cmd) => PlaySoundError::CommandError(cmd),
         PlaySoundError::SoundLimitReached => PlaySoundError::SoundLimitReached,
         PlaySoundError::IntoSoundError(input) => PlaySoundError::IntoSoundError(input.into()),
-        _ => unreachable!(),
     }
 }

--- a/src/sources/audio_file/mod.rs
+++ b/src/sources/audio_file/mod.rs
@@ -134,10 +134,7 @@ impl Default for AudioFileSettings {
 fn play_sound_error_transmute<Out>(err: PlaySoundError<()>) -> PlaySoundError<Out> {
     match err {
         PlaySoundError::SoundLimitReached => PlaySoundError::SoundLimitReached,
-        _ => unreachable!(
-            "Cannot magically go from () to {}",
-            std::any::type_name::<Out>()
-        ),
+        _ => unreachable!("Cannot convert from () to {}", std::any::type_name::<Out>()),
     }
 }
 

--- a/src/sources/audio_file/mod.rs
+++ b/src/sources/audio_file/mod.rs
@@ -134,7 +134,10 @@ impl Default for AudioFileSettings {
 fn play_sound_error_transmute<Out>(err: PlaySoundError<()>) -> PlaySoundError<Out> {
     match err {
         PlaySoundError::SoundLimitReached => PlaySoundError::SoundLimitReached,
-        _ => unreachable!("Cannot magically go from () to {}", std::any::type_name::<Out>()),
+        _ => unreachable!(
+            "Cannot magically go from () to {}",
+            std::any::type_name::<Out>()
+        ),
     }
 }
 

--- a/src/sources/audio_file/source.rs
+++ b/src/sources/audio_file/source.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 use bevy::asset::Asset;
 use bevy::prelude::*;
-use bevy::utils::error;
 use kira::manager::error::PlaySoundError;
 use kira::manager::AudioManager;
 use kira::sound::static_sound::{StaticSoundData, StaticSoundHandle, StaticSoundSettings};
@@ -162,13 +161,12 @@ impl AudioFileHandle {
     ///
     /// Note that Kira has a special "stopped" state, which means the file has completely
     /// finished playing, and cannot be resumed (an error will be logged if that's the case).
-    pub fn toggle(&mut self, tween: Tween) -> Result<(), CommandError> {
+    pub fn toggle(&mut self, tween: Tween) {
         match self.playback_state() {
             PlaybackState::Playing => self.pause(tween),
             PlaybackState::Pausing | PlaybackState::Paused => self.resume(tween),
             PlaybackState::Stopping | PlaybackState::Stopped => {
                 error!("Audio file has stopped and cannot be resumed again");
-                Ok(())
             }
         }
     }

--- a/src/sources/audio_file/source.rs
+++ b/src/sources/audio_file/source.rs
@@ -1,9 +1,10 @@
 //! Implementation of [`AudioSource`] for an audio file on disk, loaded either fully in memory,
 //! or by streaming the file directly from disk.
 
-use crate::backend::AudioBackend;
-use crate::prelude::{AudioFileError, AudioFileSettings, AudioSource};
-use crate::sources::audio_file;
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use bevy::asset::Asset;
 use bevy::prelude::*;
 use bevy::utils::error;
@@ -13,10 +14,11 @@ use kira::sound::static_sound::{StaticSoundData, StaticSoundHandle, StaticSoundS
 use kira::sound::streaming::{StreamingSoundData, StreamingSoundHandle, StreamingSoundSettings};
 use kira::sound::{FromFileError, PlaybackRate, PlaybackState, Region};
 use kira::tween::{Tween, Value};
-use kira::{CommandError, OutputDestination, Volume};
-use std::io::Cursor;
-use std::path::PathBuf;
-use std::sync::Arc;
+use kira::{OutputDestination, StartTime, Volume};
+
+use crate::backend::AudioBackend;
+use crate::prelude::{AudioFileError, AudioFileSettings, AudioSource};
+use crate::sources::audio_file;
 
 /// Bevy [`Asset`] implementation that wraps audio data for [`kira`].
 ///
@@ -43,29 +45,30 @@ impl AudioSource for AudioFile {
     fn create_handle(
         &self,
         manager: &mut AudioManager<AudioBackend>,
-        settings: &Self::Settings,
+        asset_settings: &Self::Settings,
         output_destination: OutputDestination,
     ) -> Result<Self::Handle, Self::Error> {
-        let start_paused = settings.start_paused;
+        let start_paused = asset_settings.start_paused;
         match self {
             Self::Static(data, kira_settings) => {
                 let settings = (*kira_settings)
                     .output_destination(output_destination)
-                    .volume(settings.volume)
-                    .panning(settings.panning)
-                    .loop_region(settings.loop_region)
-                    .reverse(settings.reverse)
-                    .playback_region(settings.play_region);
-                let static_data = StaticSoundData::from_cursor(Cursor::new(data.clone()), settings)
+                    .volume(asset_settings.volume)
+                    .panning(asset_settings.panning)
+                    .loop_region(asset_settings.loop_region)
+                    .reverse(asset_settings.reverse)
+                    .start_position(asset_settings.play_region.start);
+                let static_data = StaticSoundData::from_cursor(Cursor::new(data.clone()))
                     .map_err(|err| {
                         PlaySoundError::IntoSoundError(AudioFileError::FromFileError(err))
-                    })?;
+                    })?
+                    .with_settings(settings);
                 manager
-                    .play(static_data)
+                    .play(static_data.slice(asset_settings.play_region))
                     .map_err(audio_file::play_sound_error_transmute)
                     .map(|mut handle| {
                         if start_paused {
-                            error(handle.pause(Tween::default()));
+                            handle.pause(Tween::default());
                         }
                         handle
                     })
@@ -78,20 +81,20 @@ impl AudioSource for AudioFile {
             } => {
                 let settings = (*kira_settings)
                     .output_destination(output_destination)
-                    .volume(settings.volume)
-                    .panning(settings.panning)
-                    .loop_region(settings.loop_region)
-                    .playback_region(settings.play_region);
-                let streaming_sound_data =
-                    StreamingSoundData::from_file(path, settings).map_err(|err| {
+                    .volume(asset_settings.volume)
+                    .panning(asset_settings.panning)
+                    .loop_region(asset_settings.loop_region);
+                let streaming_sound_data = StreamingSoundData::from_file(path)
+                    .map_err(|err| {
                         PlaySoundError::IntoSoundError(AudioFileError::FromFileError(err))
-                    })?;
+                    })?
+                    .with_settings(settings);
                 manager
-                    .play(streaming_sound_data)
+                    .play(streaming_sound_data.slice(asset_settings.play_region))
                     .map_err(audio_file::play_sound_error_cast)
                     .map(|mut handle| {
                         if start_paused {
-                            error(handle.pause(Tween::default()));
+                            handle.pause(Tween::default());
                         }
                         handle
                     })
@@ -107,26 +110,26 @@ impl AudioSource for AudioFile {
 pub struct AudioFileHandle(RawAudioHandleImpl);
 
 macro_rules! defer_call {
-    (fn $name:ident(&self $(, $argname:ident: $argtype:ty)*) -> $ret:ty) => {
-        defer_call!(fn $name :: $name(&self $(, $argname: $argtype)*) -> $ret);
+    (fn $name:ident(&self $(, $argname:ident: $argtype:ty)*)$( -> $ret:ty)?) => {
+        defer_call!(fn $name :: $name(&self $(, $argname: $argtype)*)$( -> $ret)?);
     };
     // Don't know how to parametrize the `mut` and be able to factor these two into one variant
-    (fn $name:ident :: $fnname:ident(&self $(, $argname:ident: $argtype:ty)*) -> $ret:ty) => {
+    (fn $name:ident :: $fnname:ident(&self $(, $argname:ident: $argtype:ty)*)$( -> $ret:ty)?) => {
        /// Forwarded call to [`StaticSoundHandle`] or [`StreamingSoundHandle`].
        ///
        /// Note: Documentation cannot be provided directly due to limitations with docs in macros.
-       pub fn $fnname(&self, $($argname: $argtype),*) -> $ret {
+       pub fn $fnname(&self, $($argname: $argtype),*)$( -> $ret)? {
             match self {
                 Self(RawAudioHandleImpl::Static(handle)) => handle.$name($($argname),*),
                 Self(RawAudioHandleImpl::Streaming(handle)) => handle.$name($($argname),*),
             }
         }
     };
-    (fn $name:ident(&mut self $(, $argname:ident: $argtype:ty)*) -> $ret:ty) => {
+    (fn $name:ident(&mut self $(, $argname:ident: $argtype:ty)*)$( -> $ret:ty)?) => {
        /// Forwarded call to [`StaticSoundHandle`] or [`StreamingSoundHandle`].
        ///
        /// Note: Documentation cannot be provided directly due to limitations with docs in macros.
-        pub fn $name(&mut self, $($argname: $argtype),*) -> $ret {
+        pub fn $name(&mut self, $($argname: $argtype),*)$( -> $ret)? {
             match self {
                 Self(RawAudioHandleImpl::Static(handle)) => handle.$name($($argname),*),
                 Self(RawAudioHandleImpl::Streaming(handle)) => handle.$name($($argname),*),
@@ -138,16 +141,17 @@ macro_rules! defer_call {
 impl AudioFileHandle {
     defer_call!(fn state :: playback_state(&self) -> PlaybackState);
     defer_call!(fn position(&self) -> f64);
-    defer_call!(fn set_playback_rate(&mut self, rate: impl Into<Value<PlaybackRate>>, tween: Tween) -> Result<(), CommandError>);
-    defer_call!(fn set_panning(&mut self, panning: impl Into<Value<f64>>, tween: Tween) -> Result<(), CommandError>);
-    defer_call!(fn set_playback_region(&mut self, region: impl Into<Region>) -> Result<(), CommandError>);
-    defer_call!(fn set_loop_region(&mut self, region: impl Into<Region>) -> Result<(), CommandError>);
-    defer_call!(fn set_volume(&mut self, volume: impl Into<Value<Volume>>, tween: Tween) -> Result<(), CommandError>);
-    defer_call!(fn pause(&mut self, tween: Tween) -> Result<(), CommandError>);
-    defer_call!(fn resume(&mut self, tween: Tween) -> Result<(), CommandError>);
-    defer_call!(fn stop(&mut self, tween: Tween) -> Result<(), CommandError>);
-    defer_call!(fn seek_to(&mut self, position: f64) -> Result<(), CommandError>);
-    defer_call!(fn seek_by(&mut self, amount: f64) -> Result<(), CommandError>);
+    defer_call!(fn set_playback_rate(&mut self, rate: impl Into<Value<PlaybackRate>>, tween: Tween));
+    defer_call!(fn set_panning(&mut self, panning: impl Into<Value<f64>>, tween: Tween));
+    //defer_call!(fn set_playback_region(&mut self, region: impl Into<Region>));
+    defer_call!(fn set_loop_region(&mut self, region: impl Into<Region>));
+    defer_call!(fn set_volume(&mut self, volume: impl Into<Value<Volume>>, tween: Tween));
+    defer_call!(fn pause(&mut self, tween: Tween));
+    defer_call!(fn resume(&mut self, tween: Tween));
+    defer_call!(fn resume_at(&mut self, start_time: StartTime, tween: Tween));
+    defer_call!(fn stop(&mut self, tween: Tween));
+    defer_call!(fn seek_to(&mut self, position: f64));
+    defer_call!(fn seek_by(&mut self, amount: f64));
 }
 
 impl AudioFileHandle {

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -127,13 +127,12 @@ impl<T: AudioSource> AudioSourcePlugin<T> {
             Without<AudioHandle<T::Handle>>,
         >,
     ) {
-        let main_track_handle = audio_world.audio_manager.main_track();
         for (entity, source, settings, spatial_emitter, output_destination) in &q_added {
             let output_destination = if let Some(emitter) = spatial_emitter {
                 kira::OutputDestination::Emitter(emitter.0.id())
             } else {
                 let output_handle = match output_destination {
-                    OutputDestination::MainOutput => &main_track_handle,
+                    OutputDestination::MainOutput => &*audio_world.audio_manager.main_track(),
                 };
                 kira::OutputDestination::Track(output_handle.id())
             };

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -146,20 +146,15 @@ fn add_emitters(
 fn update_listeners(mut q: Query<(&mut SpatialListenerHandle, &GlobalTransform)>) {
     for (mut listener, global_transform) in &mut q {
         let (_, quat, position) = global_transform.to_scale_rotation_translation();
-        listener.0.set_position(position, Tween::default()).unwrap();
-        listener.0.set_orientation(quat, Tween::default()).unwrap();
+        listener.0.set_position(position, Tween::default());
+        listener.0.set_orientation(quat, Tween::default());
     }
 }
 
 fn update_emitters(mut q: Query<(Entity, &mut SpatialEmitterHandle, &GlobalTransform)>) {
     for (entity, mut emitter, global_transform) in &mut q {
         let position = global_transform.translation();
-        match emitter.0.set_position(position, Tween::default()) {
-            Ok(_) => {}
-            Err(err) => {
-                error!("Cannot set spatial audio position for entity {entity:?}: {err}");
-            }
-        }
+        emitter.0.set_position(position, Tween::default());
     }
 }
 

--- a/src/spatial.rs
+++ b/src/spatial.rs
@@ -151,8 +151,8 @@ fn update_listeners(mut q: Query<(&mut SpatialListenerHandle, &GlobalTransform)>
     }
 }
 
-fn update_emitters(mut q: Query<(Entity, &mut SpatialEmitterHandle, &GlobalTransform)>) {
-    for (entity, mut emitter, global_transform) in &mut q {
+fn update_emitters(mut q: Query<(&mut SpatialEmitterHandle, &GlobalTransform)>) {
+    for (mut emitter, global_transform) in &mut q {
         let position = global_transform.translation();
         emitter.0.set_position(position, Tween::default());
     }


### PR DESCRIPTION
Closes #11.

## Description

Upgrading Kira to 0.9 meant that most of the fallible methods disappeared, which in turn automatically solved the issue.

## Breaking changes

`AudioFileHandle` methods no longer return `Result`s, error handling is therefore not required anymore.