### PR TITLE
Add playback_rate to settings

### DIFF
--- a/src/sources/audio_file/mod.rs
+++ b/src/sources/audio_file/mod.rs
@@ -107,6 +107,11 @@ pub struct AudioFileSettings {
     pub start_paused: bool,
     /// Volume at which the audio will play at.
     pub volume: f64,
+    /// The playback rate of the sound.
+    ///
+    /// Changing the playback rate changes both the speed and the pitch of the
+    /// sound.
+    pub playback_rate: f64,
     /// Panning (in 0..=1) for the sound, where 0 is hard left, and 1 is hard right.
     pub panning: f64,
     /// Optionally loop a region of the sound (given in seconds)
@@ -123,6 +128,7 @@ impl Default for AudioFileSettings {
         Self {
             start_paused: false,
             volume: 1.0,
+            playback_rate: 1.0,
             panning: 0.5,
             loop_region: None,
             play_region: Region::from(..),

--- a/src/sources/audio_file/source.rs
+++ b/src/sources/audio_file/source.rs
@@ -53,10 +53,12 @@ impl AudioSource for AudioFile {
                 let settings = (*kira_settings)
                     .output_destination(output_destination)
                     .volume(asset_settings.volume)
+                    .playback_rate(asset_settings.playback_rate)
                     .panning(asset_settings.panning)
                     .loop_region(asset_settings.loop_region)
                     .reverse(asset_settings.reverse)
                     .start_position(asset_settings.play_region.start);
+
                 let static_data = StaticSoundData::from_cursor(Cursor::new(data.clone()))
                     .map_err(|err| {
                         PlaySoundError::IntoSoundError(AudioFileError::FromFileError(err))
@@ -81,6 +83,7 @@ impl AudioSource for AudioFile {
                 let settings = (*kira_settings)
                     .output_destination(output_destination)
                     .volume(asset_settings.volume)
+                    .playback_rate(asset_settings.playback_rate)
                     .panning(asset_settings.panning)
                     .loop_region(asset_settings.loop_region);
                 let streaming_sound_data = StreamingSoundData::from_file(path)


### PR DESCRIPTION
Fixes #20

## Description

As with `volume`, only support fixed playback rates and so just expose it as an f64/`Fixed`.

Usage:

```rust
commands.spawn(
    AudioFileBundle {
        source,
        settings: AudioFileSettings {
            loop_region,
            volume,
            playback_rate: 0.25, // play at 25% of the usual speed
            ..default()
        },
        ..default()
    },
);
```

I decided not to update or add an example because the `audio_control` example already adjusts playback rate per frame and this new feature is just for setting an initial starting playback rate so it's not really that interesting.